### PR TITLE
feat: Improvements to pygments styles

### DIFF
--- a/catppuccin/extras/pygments.py
+++ b/catppuccin/extras/pygments.py
@@ -16,6 +16,7 @@ from pygments.token import (
     String,
     Text,
     Token,
+    Generic,
     _TokenType,
 )
 
@@ -48,6 +49,7 @@ def _make_styles(flavour: Flavour) -> Dict[_TokenType, str]:
         Punctuation: f"#{flavour.text.hex}",
         Operator: f"#{flavour.sky.hex}",
         Comment: f"#{flavour.overlay0.hex}",
+        Generic.Heading: f"#{flavour.blue.hex} bold",
     }
 
 

--- a/catppuccin/extras/pygments.py
+++ b/catppuccin/extras/pygments.py
@@ -55,23 +55,43 @@ def _make_styles(flavour: Flavour) -> Dict[_TokenType, str]:
 
 class LatteStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Latte pygments style."""
+    _flavour = Flavour.latte()
 
-    styles = _make_styles(Flavour.latte())
+    background_color = f"#{_flavour.base.hex}"
+    line_number_background_color = f"#{_flavour.mantle.hex}"
+    line_number_color = f"#{_flavour.text.hex}"
+
+    styles = _make_styles(_flavour)
 
 
 class FrappeStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Frappé pygments style."""
+    _flavour = Flavour.frappe()
 
-    styles = _make_styles(Flavour.frappe())
+    background_color = f"#{_flavour.base.hex}"
+    line_number_background_color = f"#{_flavour.mantle.hex}"
+    line_number_color = f"#{_flavour.text.hex}"
+
+    styles = _make_styles(_flavour)
 
 
 class MacchiatoStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Macchiato pygments style."""
+    _flavour = Flavour.macchiato()
 
-    styles = _make_styles(Flavour.macchiato())
+    background_color = f"#{_flavour.base.hex}"
+    line_number_background_color = f"#{_flavour.mantle.hex}"
+    line_number_color = f"#{_flavour.text.hex}"
+
+    styles = _make_styles(_flavour)
 
 
 class MochaStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Mocha pygments style."""
+    _flavour = Flavour.mocha()
 
-    styles = _make_styles(Flavour.mocha())
+    background_color = f"#{_flavour.base.hex}"
+    line_number_background_color = f"#{_flavour.mantle.hex}"
+    line_number_color = f"#{_flavour.text.hex}"
+
+    styles = _make_styles(_flavour)

--- a/catppuccin/extras/pygments.py
+++ b/catppuccin/extras/pygments.py
@@ -7,6 +7,7 @@ from pygments.style import Style
 from pygments.token import (
     Comment,
     Error,
+    Generic,
     Keyword,
     Literal,
     Name,
@@ -16,7 +17,6 @@ from pygments.token import (
     String,
     Text,
     Token,
-    Generic,
     _TokenType,
 )
 
@@ -55,6 +55,7 @@ def _make_styles(flavour: Flavour) -> Dict[_TokenType, str]:
 
 class LatteStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Latte pygments style."""
+
     _flavour = Flavour.latte()
 
     background_color = f"#{_flavour.base.hex}"
@@ -66,6 +67,7 @@ class LatteStyle(Style):  # pylint: disable=too-few-public-methods
 
 class FrappeStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Frappé pygments style."""
+
     _flavour = Flavour.frappe()
 
     background_color = f"#{_flavour.base.hex}"
@@ -77,6 +79,7 @@ class FrappeStyle(Style):  # pylint: disable=too-few-public-methods
 
 class MacchiatoStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Macchiato pygments style."""
+
     _flavour = Flavour.macchiato()
 
     background_color = f"#{_flavour.base.hex}"
@@ -88,6 +91,7 @@ class MacchiatoStyle(Style):  # pylint: disable=too-few-public-methods
 
 class MochaStyle(Style):  # pylint: disable=too-few-public-methods
     """Catppuccin Mocha pygments style."""
+
     _flavour = Flavour.mocha()
 
     background_color = f"#{_flavour.base.hex}"


### PR DESCRIPTION
- Added Generic.Heading, which is used for styling Markdown. Used `blue`, following the [Catppuccin Sublime theme](https://github.com/catppuccin/sublime-text)
- Added IDE colours (background and line number colours), again following colours used by the [Catppuccin Sublime theme](https://github.com/catppuccin/sublime-text)