### PR TITLE
revert(css): remove extra `pre[lang]` selector

### DIFF
--- a/scripts/build-gh-pages
+++ b/scripts/build-gh-pages
@@ -54,7 +54,7 @@ def postprocess_css(content: str, important: bool) -> str:
 def flavor_css(flavor: str) -> str:
     style = PYGMENTS_STYLES[flavor]
     formatter = HtmlFormatter(style=style)
-    return formatter.get_style_defs(["pre", "pre[lang]"])
+    return formatter.get_style_defs("pre")
 
 
 def variable_css() -> str:


### PR DESCRIPTION
Not needed anymore with the !important variant of the stylesheet :p