### PR TITLE
fix(scripts/build-gh-pages): add `code` selector for pygments styles

### DIFF
--- a/scripts/build-gh-pages
+++ b/scripts/build-gh-pages
@@ -54,7 +54,7 @@ def postprocess_css(content: str, important: bool) -> str:
 def flavor_css(flavor: str) -> str:
     style = PYGMENTS_STYLES[flavor]
     formatter = HtmlFormatter(style=style)
-    return formatter.get_style_defs("pre")
+    return formatter.get_style_defs(["pre", "code"])
 
 
 def variable_css() -> str:


### PR DESCRIPTION
Allows for the theming of syntax highlighted inline `code` blocks in addition to the existing theming of multiline `pre` blocks.