### PR TITLE
Move iterable docstring from Flavor to FlavorColors

### DIFF
--- a/catppuccin/models.py
+++ b/catppuccin/models.py
@@ -37,7 +37,10 @@ class Color:
 
 @dataclass(frozen=True)
 class FlavorColors:
-    """All of the colors for a particular flavor of Catppuccin."""
+    """All of the colors for a particular flavor of Catppuccin.
+
+    Can be iterated over, in which case the colors are yielded in order.
+    """
 
     rosewater: Color
     flamingo: Color
@@ -103,7 +106,6 @@ class Flavor:
     """A flavor is a collection of colors.
 
     Catppuccin has four flavors; Latte, Frappé, Macchiato, and Mocha.
-    Can be iterated over, in which case the colors are yielded in order.
     """
 
     name: str


### PR DESCRIPTION
Current `Flavor` docstring wrongly states that it's iterable (`Can be iterated over, in which case the colors are yielded in order.`). I assume this was ment to be put in `FlavorColors` instead.

Simply moved the docstring part there. If you prefer, I can make `Flavor` an actual iterator which iterates over its colors.