### PR TITLE
fix(pygments): punctuations should be ``teal`` instead of ``overlay2``

### DIFF
--- a/catppuccin/extras/pygments.py
+++ b/catppuccin/extras/pygments.py
@@ -99,7 +99,7 @@ def _make_styles(colors: FlavorColors) -> dict[_TokenType, str]:
         Operator.Word: colors.mauve.hex,
         Other: colors.text.hex,
         # `(`, `)`, `,`, `[`, `]`, `:`
-        Punctuation: colors.overlay2.hex,
+        Punctuation: colors.teal.hex,
         String: colors.green.hex,
         String.Backtick: colors.green.hex,
         String.Char: colors.green.hex,


### PR DESCRIPTION
I checked the colors to see if they match with the vscode/nvim ports and they [dont seem to match](https://github.com/catppuccin/vscode/blob/54316f9afc31c3b5070a242cd3ca47d66ab0e9ac/packages/catppuccin-vsc/src/theme/tokens/index.ts#L120) so I'll go ahead and update this.