### PR TITLE
Fix #129 (caused by matplotlib 3.11 deprecating mpl.style.core)

### DIFF
--- a/catppuccin/extras/matplotlib.py
+++ b/catppuccin/extras/matplotlib.py
@@ -72,6 +72,7 @@ from typing import TYPE_CHECKING, cast
 import matplotlib as mpl
 import matplotlib.colors
 import matplotlib.style
+from matplotlib import rc_params_from_file
 
 from catppuccin.palette import PALETTE
 
@@ -84,10 +85,10 @@ DEFAULT_COLORMAP_COLORS = ("base", "blue")
 
 def _register_styles() -> None:
     """Register the included stylesheets in the mpl style library."""
-    catppuccin_stylesheets = mpl.style.core.read_style_directory(  # type: ignore [attr-defined]
-        CATPPUCCIN_STYLE_DIRECTORY
-    )
-    mpl.style.core.update_nested_dict(mpl.style.library, catppuccin_stylesheets)  # type: ignore [attr-defined]
+    for path in Path(CATPPUCCIN_STYLE_DIRECTORY).glob(f"*.mplstyle"):
+        stylename = path.stem
+        style = rc_params_from_file(path, use_default_template=False)
+        mpl.style.library.setdefault(stylename, {}).update(style)
 
 
 def _register_colormap_list() -> None:


### PR DESCRIPTION
Solves the problem by direct implementation: Read the files and update `mpl.style.library` directly:

```py
def _register_styles() -> None:
    """Register the included stylesheets in the mpl style library."""
    for path in Path(CATPPUCCIN_STYLE_DIRECTORY).glob(f"*.mplstyle"):
        stylename = path.stem
        style = rc_params_from_file(path, use_default_template=False)
        mpl.style.library.setdefault(stylename, {}).update(style)
```